### PR TITLE
SDK-399 | Deploy error fix

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -367,9 +367,10 @@ export default class Git {
         ? await execPromise("git", ["rev-parse", start])
         : "";
 
+      const maxNumber = 2147483647;
       const log = await gitlog({
         repo: process.cwd(),
-        number: Number.MAX_SAFE_INTEGER,
+        number: maxNumber,
         fields: ["hash", "authorName", "authorEmail", "rawBody"],
         // If start === firstCommit then we want to include that commit in the changelog
         // Otherwise it was that last release and should not be included in the release.


### PR DESCRIPTION
# What Changed

- Fixed a `' 9007199254740991': not an integer` deploy error

## Why

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
